### PR TITLE
Fix JSP syntax in XSS Contexts > CSS

### DIFF
--- a/slides/02-02-xss.md
+++ b/slides/02-02-xss.md
@@ -303,8 +303,8 @@ the above contexts but is less efficient as it encodes more characters._
 ### CSS
 
 ```
-<div style="width:<= Encode.forCssString(UNTRUSTED) %>">
-<div style="background:<= Encode.forCssUrl(UNTRUSTED) %>">
+<div style="width: <%= Encode.forCssString(UNTRUSTED) %>">
+<div style="background: <%= Encode.forCssUrl(UNTRUSTED) %>">
 ```
 
 ### URL Parameter


### PR DESCRIPTION
The space is for better reading.
The '%' is to fix a syntax error.