### PR TITLE
Fix Java class reference

### DIFF
--- a/slides/02-02-xss.md
+++ b/slides/02-02-xss.md
@@ -240,9 +240,9 @@ Using `Encoder` from
 [OWASP Java Encoder Project](https://wiki.owasp.org/index.php/OWASP_Java_Encoder_Project):
 
 ```
-<%import org.owasp.encoder.Encoder;%>
+<%import org.owasp.encoder.Encode;%>
 
-Search results for <b><%=Encoder.forHtml(searchCriteria)%></b>:
+Search results for <b><%=Encode.forHtml(searchCriteria)%></b>:
 <!-- ... -->
 ```
 


### PR DESCRIPTION
org.owasp.encoder.Encoder is the low-level utility class.
org.owasp.encoder.Encode is the class to use for contextual encoding which contains the forHtml method.